### PR TITLE
Fix counting number of table rows

### DIFF
--- a/texprlcount.pl
+++ b/texprlcount.pl
@@ -55,7 +55,7 @@ close $logfileh;
 close $texfileh;
 
 # We strip comments from the tex file
-$texfile =~ s/%[^\n]*//g;
+$texfile =~ s/[^\\]%[^\n]*//g;
 
 # We count the number of characters in the abstract
 my $abstract;

--- a/texprlcount.pl
+++ b/texprlcount.pl
@@ -125,6 +125,8 @@ foreach (@tables) {
 	$tablecount++;
 	$tablelinecount += () = $_ =~ /\\\\/g;
 	$tablelinecount += () = $_ =~ /\\tabularnewline/g;
+	$tablelinecount -= () = $_ =~ /\\hline[\s]*$/g;
+	$tablelinecount -= () = $_ =~ /\\\\[\s]*$/g;
 	$tablelinecount++;
 }
 


### PR DESCRIPTION
I had an issue with the counting of number of table rows due to \% in the lines, which as they were interpreted as comments got removed (and hence the \\ at the end of the line).

A secondary issue I had was with the fact that I have a \\ at the end of the last line in the table (because I add a \hline afterwards), and because of that the last "$tablelinecount" added one row too many.

Thanks a lot for the script!

Cheers,