### PR TITLE
Get rid of Math::Round and List::MoreUtils dependence.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Usage
 ------------
 In order to use `texprlcount`, do the following
 
-1. Make sure that `texcount` is installed (most TeX distributions include it) and `Math::Round module` perl module. They may be installed by e.g., `apt install texlive-extra-utils libmath-round-perl` on debian sytems.
+1. Make sure that `texcount` is installed (most TeX distributions include it).  It may be installed by e.g., `apt install texlive-extra-utils` on Debian sytems.
 2. Fetch the `texprlcount` script, e.g.,
 
          wget https://raw.githubusercontent.com/matteoacrossi/texprlcount/master/texprlcount.pl


### PR DESCRIPTION
From what I understand, only the `nearest` subroutine of Math::Round and the `first_index` subroutine of List::MoreUtils is used by this script.  So I think it would benefit people who can't install Perl modules on their system if we just included those two subroutines in the script and got rid of the module dependency.  This way we would only rely on the standard/core modules.