### PR TITLE
Fix comment regex

### DIFF
--- a/texprlcount.pl
+++ b/texprlcount.pl
@@ -83,7 +83,7 @@ close $logfileh;
 close $texfileh;
 
 # We strip comments from the tex file
-$texfile =~ s/[^\\]%[^\n]*//g;
+$texfile =~ s/(?<!\\)%.*//g;
 
 # We count the number of characters in the abstract
 my $abstract;


### PR DESCRIPTION
This PR fixes an issue with the comment stripping regex that would strip the character before a comment if there was no space. 

This caused issues with parsing figure names if the `.tex` file looked like, e.g., 
```
\begin{figure}
\includegraphics[\linewidth]{myfig.pdf}%
\caption{whatever}
\end{figure}
```
, the `}%` would be stripped, leading to the `imgname` being `myfig.pdf\n\caption{whatever`.